### PR TITLE
Correcting ci working directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ jobs:
   build:
     docker:
       - image: circleci/node:10.15
-    working_directory: ~/
-
     steps:
       - checkout
 


### PR DESCRIPTION
I copied an example for the config and it had the wrong working directory to build correctly.