### PR TITLE
docs: correcting example configuration link

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ desktop --file application.yaml
 Configuration can be loaded locally or from a url:
 
 ```bash
-desktop -f https://gitlab.com/reactivemarkets/desktop/examples/config/raw/master/examples/single-window.yaml
+desktop -f https://raw.githubusercontent.com/desktop-examples/config/master/examples/single-window.yaml
 ```
 
 ## Building from source


### PR DESCRIPTION
The example configuration was still pointing at gitlab.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.
-->

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated
- [x] tests are added
