### PR TITLE
fix(desktop): using cd instead of pushd

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build asar
         run: |
           npm run asar
-      - name: npm package
+      - name: Build packages
         run: |
           npm run package:${{ matrix.platform }}
       - name: "Get upload_url"

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -30,10 +30,10 @@
     "installer:dmg": "electron-installer-dmg pack/desktop-darwin-x64/desktop.app desktop-$npm_package_version --overwrite --title Desktop --background src/img/dmg-background.png --icon src/img/desktop.icns --protocol=desktop --protocol-name \"Desktop Protocol\" --darwin-dark-mode-support --out pack",
     "installer:windows": "electron-installer-windows --src pack/desktop-win32-x64/ --dest pack/desktop-$npm_package_version-win32-x64-exe/ --options.version $npm_package_version --config windows.json",
     "zip": "run-s zip:darwin zip:linux zip:win32 zip:win32:installer",
-    "zip:darwin": "pushd pack/desktop-darwin-x64 && zip -r -q --symlinks ../desktop-$npm_package_version-darwin-x64.zip * && popd",
-    "zip:linux": "pushd pack/desktop-linux-x64 && zip -r -q --symlinks ../desktop-$npm_package_version-linux-x64.zip * && popd",
-    "zip:win32": "pushd pack/desktop-win32-x64 && zip -r -q --symlinks ../desktop-$npm_package_version-win32-x64.zip * && popd",
-    "zip:win32:installer": "pushd pack/desktop-$npm_package_version-win32-x64-exe && zip -q ../desktop-$npm_package_version-win32-x64-setup.zip * && popd"
+    "zip:darwin": "cd pack/desktop-darwin-x64 && zip -r -q --symlinks ../desktop-$npm_package_version-darwin-x64.zip * && cd ../..",
+    "zip:linux": "cd pack/desktop-linux-x64 && zip -r -q --symlinks ../desktop-$npm_package_version-linux-x64.zip * && cd ../..",
+    "zip:win32": "cd pack/desktop-win32-x64 && zip -r -q --symlinks ../desktop-$npm_package_version-win32-x64.zip * && cd ../..",
+    "zip:win32:installer": "cd pack/desktop-$npm_package_version-win32-x64-exe && zip -q ../desktop-$npm_package_version-win32-x64-setup.zip * && cd ../.."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated
- [x] tests are added

#### Changes
- pushd doesn't exist on the build machines.
