### PR TITLE
fix(sdk): publish config should be public

### DIFF
--- a/packages/desktop-sdk/package.json
+++ b/packages/desktop-sdk/package.json
@@ -2,6 +2,9 @@
   "name": "@reactivemarkets/desktop-sdk",
   "version": "0.5.0",
   "description": "SDK for desktop.",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [


### PR DESCRIPTION
#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated
- [x] tests are added

#### Changes
* The package is being published to the public npm and needs public access.