### PR TITLE
docs: correcting fossa status link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,8 @@ npm run build
 
 ## License
 
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Freactivemarkets%2Fdesktop.svg?type=large)](https://app.fossa.com/api/projects/git%2Bgithub.com%2Freactivemarkets%2Fdesktop.svg?type=large)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Freactivemarkets%2Fdesktop.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Freactivemarkets%2Fdesktop?ref=badge_large)
+
+
+https://app.fossa.com/projects/git%2Bgithub.com%2Freactivemarkets%2Fdesktop?ref=badge_large
+https://app.fossa.io/projects/git%2Bgithub.com%2Fsentialx%2Fmultrin?ref=badge_large


### PR DESCRIPTION
#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] documentation is updated
- [x] tests are added

#### Changes
Fixing fossa status link. The link just opening the image instead of the project page.
