### PR TITLE
build!: fixing windows builds

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           upload_url: ${{ steps.release.outputs.upload_url }}
           asset_path: packages/desktop/pack/Desktop-${{ steps.version.outputs.version }}-win32-x64.zip
-          asset_name: Desktop-${{ steps.version.outputs.version }}-win-x64.zip
+          asset_name: Desktop-${{ steps.version.outputs.version }}-win32-x64.zip
           asset_content_type: application/zip
       - name: Upload Package Installer
         uses: actions/upload-release-asset@v1
@@ -49,8 +49,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: packages/desktop/pack/Desktop-${{ steps.version.outputs.version }}-win.exe
-          asset_name: Desktop-${{ steps.version.outputs.version }}-win.exe
+          asset_path: packages/desktop/pack/Desktop-${{ steps.version.outputs.version }}-win32.exe
+          asset_name: Desktop-${{ steps.version.outputs.version }}-win32.exe
           asset_content_type: application/octet-stream
       - name: Upload Package Installer Blockmap
         uses: actions/upload-release-asset@v1
@@ -58,8 +58,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: packages/desktop/pack/Desktop-${{ steps.version.outputs.version }}-win.exe.blockmap
-          asset_name: Desktop-${{ steps.version.outputs.version }}-win.exe.blockmap
+          asset_path: packages/desktop/pack/Desktop-${{ steps.version.outputs.version }}-win32.exe.blockmap
+          asset_name: Desktop-${{ steps.version.outputs.version }}-win32.exe.blockmap
           asset_content_type: application/octet-stream
       - name: Upload Latest.yml
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
- [ ] tests are added

#### Changes
The builds are output with win32 not win.
