### PR TITLE
fix(desktop): missing zip targets for windows and linux

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -32,6 +32,7 @@ linux:
     - target: AppImage
     - target: snap
     - target: deb
+    - target: zip
 deb:
   afterInstall: build/after-install.tpl
   afterRemove: build/after-remove.tpl
@@ -60,5 +61,6 @@ dmg:
 win:
   target:
     - target: nsis
+    - target: zip
 nsis:
   deleteAppDataOnUninstall: true


### PR DESCRIPTION
Adding to target lists.

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
- [ ] tests are added

#### Changes
zip targets were missing for windows and linux.