### PR TITLE
fix(dock): dock shouldn't expand after clearing the search term

### DIFF
--- a/packages/desktop-dock/src/components/Search/SearchAutocompleteContainer.tsx
+++ b/packages/desktop-dock/src/components/Search/SearchAutocompleteContainer.tsx
@@ -43,7 +43,7 @@ export class SearchAutocompleteContainer extends React.Component<ISearchAutocomp
             reaction(
                 () => this.props.searchStore?.term,
                 (term) => {
-                    if (term !== "") {
+                    if (term !== undefined && term !== "") {
                         this.props.resizerStore?.expand();
                     }
                 },


### PR DESCRIPTION
Checking if term is undefined before expanding window.

#### Checklist
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] documentation is updated
- [ ] tests are added

#### Changes
- Don't expand dock after clearing search term.
